### PR TITLE
Fix transparency and culling bug

### DIFF
--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialDescriptorGenerator.cs
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialDescriptorGenerator.cs
@@ -12,7 +12,7 @@ using VRMShaders;
 namespace Segur.PolySpatialEnvironmentDiffuseShader.Runtime
 {
     /// <summary>
-    /// VRM MaterialDescriptorGenerator for URP EnvironmentDiffuseShader
+    /// VRM MaterialDescriptorGenerator for PolySpatial EnvironmentDiffuseShader
     /// This will be used on VisionOS
     /// </summary>
     public sealed class EnvironmentDiffuseMaterialDescriptorGenerator : IMaterialDescriptorGenerator

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialDescriptorGenerator.cs
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialDescriptorGenerator.cs
@@ -19,7 +19,7 @@ namespace Segur.PolySpatialEnvironmentDiffuseShader.Runtime
     {
         public const string ShaderName = "Segur/PolySpatial/EnvironmentDiffuse";
 
-        private static readonly Shader TargetShader = Shader.Find(ShaderName);
+        public static readonly Shader TargetShader = Shader.Find(ShaderName);
 
         public MaterialDescriptor Get(GltfData data, int i)
         {
@@ -64,10 +64,13 @@ namespace Segur.PolySpatialEnvironmentDiffuseShader.Runtime
                 TargetShader,
                 null,
                 ReplaceTextureSlots(inputMaterialDescriptor.TextureSlots),
-                new Dictionary<string, float>(),
+                inputMaterialDescriptor.FloatValues,
                 ReplaceColors(inputMaterialDescriptor.Colors),
-                new Dictionary<string, Vector4>(),
-                new Action<Material>[] { });
+                inputMaterialDescriptor.Vectors,
+                new Action<Material>[]
+                {
+                    material => { new EnvironmentDiffuseMaterialParameterAdjuster(material).Validate(); }
+                });
 
             return outputMaterialDescriptor;
         }

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialParameterAdjuster.cs
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialParameterAdjuster.cs
@@ -1,0 +1,129 @@
+#if COM_VRMC_GLTF && COM_VRMC_VRM && COM_VRMC_VRMSHADERS
+
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+using VRMShaders.VRM10.MToon10.Runtime;
+
+// This code is based on Packages/com.vrmc.vrmshaders/VRM10/MToon10/Runtime/MToonValidator.cs
+// ReSharper disable once CheckNamespace
+namespace Segur.PolySpatialEnvironmentDiffuseShader.Runtime
+{
+    /// <summary>
+    /// Adjust parameters of PolySpatial EnvironmentDiffuseShader
+    /// This will be used on VisionOS
+    /// </summary>
+    public sealed class EnvironmentDiffuseMaterialParameterAdjuster
+    {
+        private static readonly int Surface = Shader.PropertyToID("_Surface");
+        private static readonly int AlphaClip = Shader.PropertyToID("_AlphaClip");
+        private static readonly int AlphaClipThreshold = Shader.PropertyToID("_AlphaClipThreshold");
+        private static readonly int SrcBlend = Shader.PropertyToID("_SrcBlend");
+        private static readonly int DstBlend = Shader.PropertyToID("_DstBlend");
+        private static readonly int ZWrite = Shader.PropertyToID("_ZWrite");
+        private static readonly int Cull = Shader.PropertyToID("_Cull");
+        private static readonly int AlphaToMask = Shader.PropertyToID("_AlphaToMask");
+        private static readonly int QueueOffset = Shader.PropertyToID("_QueueOffset");
+
+        private readonly Material _material;
+
+        public EnvironmentDiffuseMaterialParameterAdjuster(Material material)
+        {
+            _material = material;
+        }
+
+        public void Validate()
+        {
+            SetAlphaSettings();
+            SetDoubleSidedSetting();
+
+            // Refresh material
+            _material.shader = EnvironmentDiffuseMaterialDescriptorGenerator.TargetShader;
+        }
+
+        private void SetAlphaSettings()
+        {
+            var alphaMode = (MToon10AlphaMode)_material.GetInt(MToon10Prop.AlphaMode);
+            var zWriteMode = (MToon10TransparentWithZWriteMode)_material.GetInt(MToon10Prop.TransparentWithZWrite);
+            var renderQueueOffset = _material.GetInt(MToon10Prop.RenderQueueOffsetNumber);
+            var alphaCutoff = _material.GetFloat(MToon10Prop.AlphaCutoff);
+
+            switch (alphaMode)
+            {
+                case MToon10AlphaMode.Opaque:
+                    _material.SetOverrideTag(UnityRenderTag.Key, UnityRenderTag.OpaqueValue);
+                    _material.SetInt(SrcBlend, (int)BlendMode.One);
+                    _material.SetInt(DstBlend, (int)BlendMode.Zero);
+                    _material.SetInt(ZWrite, (int)UnityZWriteMode.On);
+                    _material.SetInt(AlphaToMask, (int)UnityAlphaToMaskMode.Off);
+                    _material.SetInt(Surface, 0); // Set to Opaque
+                    _material.SetInt(AlphaClip, 0); // Disable Alpha Clipping
+
+                    renderQueueOffset = 0;
+                    _material.renderQueue = (int)RenderQueue.Geometry;
+                    break;
+                case MToon10AlphaMode.Cutout:
+                    _material.SetOverrideTag(UnityRenderTag.Key, UnityRenderTag.TransparentCutoutValue);
+                    _material.SetInt(SrcBlend, (int)BlendMode.One);
+                    _material.SetInt(DstBlend, (int)BlendMode.Zero);
+                    _material.SetInt(ZWrite, (int)UnityZWriteMode.On);
+                    _material.SetInt(AlphaToMask, (int)UnityAlphaToMaskMode.On);
+                    _material.SetInt(Surface, 0); // Set to Opaque
+                    _material.SetInt(AlphaClip, 1); // Enable Alpha Clipping
+                    _material.SetFloat(AlphaClipThreshold, alphaCutoff);
+
+                    renderQueueOffset = 0;
+                    _material.renderQueue = (int)RenderQueue.AlphaTest;
+                    break;
+                case MToon10AlphaMode.Transparent when zWriteMode == MToon10TransparentWithZWriteMode.Off:
+                    _material.SetOverrideTag(UnityRenderTag.Key, UnityRenderTag.TransparentValue);
+                    _material.SetInt(SrcBlend, (int)BlendMode.SrcAlpha);
+                    _material.SetInt(DstBlend, (int)BlendMode.OneMinusSrcAlpha);
+                    _material.SetInt(ZWrite, (int)UnityZWriteMode.Off);
+                    _material.SetInt(AlphaToMask, (int)UnityAlphaToMaskMode.Off);
+                    _material.SetInt(Surface, 1); // Set to Transparent
+                    _material.SetInt(AlphaClip, 0); // Disable Alpha Clipping
+
+                    renderQueueOffset = Mathf.Clamp(renderQueueOffset, -9, 0);
+                    _material.renderQueue = (int)RenderQueue.Transparent + renderQueueOffset;
+                    break;
+                case MToon10AlphaMode.Transparent when zWriteMode == MToon10TransparentWithZWriteMode.On:
+                    _material.SetOverrideTag(UnityRenderTag.Key, UnityRenderTag.TransparentValue);
+                    _material.SetInt(SrcBlend, (int)BlendMode.SrcAlpha);
+                    _material.SetInt(DstBlend, (int)BlendMode.OneMinusSrcAlpha);
+                    _material.SetInt(ZWrite, (int)UnityZWriteMode.On);
+                    _material.SetInt(AlphaToMask, (int)UnityAlphaToMaskMode.Off);
+                    _material.SetInt(Surface, 1); // Set to Transparent
+                    _material.SetInt(AlphaClip, 0); // Disable Alpha Clipping
+
+                    renderQueueOffset = Mathf.Clamp(renderQueueOffset, 0, +9);
+                    _material.renderQueue = (int)RenderQueue.GeometryLast + 1 + renderQueueOffset;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(alphaMode), alphaMode, null);
+            }
+
+            // Set after validation
+            _material.SetInt(QueueOffset, renderQueueOffset);
+        }
+
+        private void SetDoubleSidedSetting()
+        {
+            var doubleSidedMode = (MToon10DoubleSidedMode)_material.GetInt(MToon10Prop.DoubleSided);
+
+            switch (doubleSidedMode)
+            {
+                case MToon10DoubleSidedMode.Off:
+                    _material.SetInt(Cull, (int)UnityCullMode.Back); // Cull Back, Render Front
+                    break;
+                case MToon10DoubleSidedMode.On:
+                    _material.SetInt(Cull, (int)UnityCullMode.Off); // Cull Off, Render Both
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(doubleSidedMode), doubleSidedMode, null);
+            }
+        }
+    }
+}
+
+#endif

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialParameterAdjuster.cs.meta
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/EnvironmentDiffuseMaterialParameterAdjuster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eed70097198c2486f97bbf21684e5047
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Shaders/EnvironmentDiffuse.shadergraph
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Shaders/EnvironmentDiffuse.shadergraph
@@ -14,6 +14,9 @@
         },
         {
             "m_Id": "d16ab1574b8b45a3b1f613e09d8ac5f1"
+        },
+        {
+            "m_Id": "8c7bb07588494cca891b0ca45ba379fe"
         }
     ],
     "m_Keywords": [],
@@ -65,6 +68,21 @@
         },
         {
             "m_Id": "561d5fe3b7e74050a8314717c61f14a2"
+        },
+        {
+            "m_Id": "b112733f332547ae9697de5d87832a8a"
+        },
+        {
+            "m_Id": "47104eb4715e4c56a7d64da7cc6ed0d4"
+        },
+        {
+            "m_Id": "39e611c9bf674226a3e7230590717860"
+        },
+        {
+            "m_Id": "49f23555d1c5452e90e64f0f10b86d67"
+        },
+        {
+            "m_Id": "6081aee0d2f14f91bf48511833fa30b8"
         }
     ],
     "m_GroupDatas": [],
@@ -79,9 +97,37 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "ca897788ab7d4fd1be2f453f13e8cf22"
+                    "m_Id": "49f23555d1c5452e90e64f0f10b86d67"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "39e611c9bf674226a3e7230590717860"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "47104eb4715e4c56a7d64da7cc6ed0d4"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "49f23555d1c5452e90e64f0f10b86d67"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "561d5fe3b7e74050a8314717c61f14a2"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -94,6 +140,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "ed93b1190fc240d4b1a850ed7d89f1e0"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "6081aee0d2f14f91bf48511833fa30b8"
+                },
+                "m_SlotId": 4
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "b112733f332547ae9697de5d87832a8a"
                 },
                 "m_SlotId": 0
             }
@@ -135,9 +195,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "193f6a8976524aca854f33b06d0873de"
+                    "m_Id": "ca897788ab7d4fd1be2f453f13e8cf22"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             }
         },
         {
@@ -205,7 +265,21 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "561d5fe3b7e74050a8314717c61f14a2"
+                    "m_Id": "49f23555d1c5452e90e64f0f10b86d67"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "ca897788ab7d4fd1be2f453f13e8cf22"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "6081aee0d2f14f91bf48511833fa30b8"
                 },
                 "m_SlotId": 0
             }
@@ -236,6 +310,12 @@
         "m_Blocks": [
             {
                 "m_Id": "ed93b1190fc240d4b1a850ed7d89f1e0"
+            },
+            {
+                "m_Id": "b112733f332547ae9697de5d87832a8a"
+            },
+            {
+                "m_Id": "47104eb4715e4c56a7d64da7cc6ed0d4"
             }
         ]
     },
@@ -262,6 +342,54 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "03163e6131924a07b28ba9889ca99ae7",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "05402745fdb84cbba2ff0a6937e63a23",
     "m_Id": 1,
@@ -271,6 +399,21 @@
     "m_ShaderOutputName": "Roughness",
     "m_StageCapability": 3,
     "m_Value": 1.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "05d3ff076b8a4807b9a1beb8e4ceb6a2",
+    "m_Id": 3,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }
@@ -382,8 +525,8 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1359.0,
-            "y": 352.0,
+            "x": 1417.0,
+            "y": 318.0,
             "width": 257.0,
             "height": 173.0
         }
@@ -583,6 +726,57 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "38a7c5f8425f4e52a8575493503180e6",
+    "m_Id": 2,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "39e611c9bf674226a3e7230590717860",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 2058.0,
+            "y": 739.0,
+            "width": 177.0,
+            "height": 34.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "42223ea2253b4add8449b2e1ca3c63a5"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "8c7bb07588494cca891b0ca45ba379fe"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "3b4af32084574d83a1aa2153eb972bc8",
     "m_Id": 7,
     "m_DisplayName": "A",
@@ -615,6 +809,21 @@
     },
     "m_Labels": [],
     "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "42223ea2253b4add8449b2e1ca3c63a5",
+    "m_Id": 0,
+    "m_DisplayName": "AlphaClipThreshold",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -655,7 +864,7 @@
     "m_ActiveSubTarget": {
         "m_Id": "4428c42bab964935b9bcffad53788d3d"
     },
-    "m_AllowMaterialOverride": false,
+    "m_AllowMaterialOverride": true,
     "m_SurfaceType": 0,
     "m_ZTestMode": 4,
     "m_ZWriteControl": 0,
@@ -686,6 +895,83 @@
     "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalUnlitSubTarget",
     "m_ObjectId": "4428c42bab964935b9bcffad53788d3d"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "47104eb4715e4c56a7d64da7cc6ed0d4",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.AlphaClipThreshold",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5ab6581b03c24b42b7356fa092da7cf8"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "49f23555d1c5452e90e64f0f10b86d67",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Multiply",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1755.0,
+            "y": 188.0,
+            "width": 208.0,
+            "height": 302.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5326818c293f4535bdbbaa1b19abfc9a"
+        },
+        {
+            "m_Id": "5de87e90ee5f4b8fb30fd20f8341255b"
+        },
+        {
+            "m_Id": "03163e6131924a07b28ba9889ca99ae7"
+        }
+    ],
+    "synonyms": [
+        "multiplication",
+        "times",
+        "x"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -754,6 +1040,54 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "5326818c293f4535bdbbaa1b19abfc9a",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.AddNode",
     "m_ObjectId": "561d5fe3b7e74050a8314717c61f14a2",
     "m_Group": {
@@ -764,10 +1098,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 2078.0,
-            "y": 412.0000305175781,
-            "width": 208.000244140625,
-            "height": 302.0000305175781
+            "x": 2025.0,
+            "y": 411.0,
+            "width": 208.0,
+            "height": 302.0
         }
     },
     "m_Slots": [
@@ -793,6 +1127,21 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "5ab6581b03c24b42b7356fa092da7cf8",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha Clip Threshold",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "AlphaClipThreshold",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": []
 }
 
 {
@@ -851,6 +1200,101 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "5de87e90ee5f4b8fb30fd20f8341255b",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 2.0,
+        "e01": 2.0,
+        "e02": 2.0,
+        "e03": 2.0,
+        "e10": 2.0,
+        "e11": 2.0,
+        "e12": 2.0,
+        "e13": 2.0,
+        "e20": 2.0,
+        "e21": 2.0,
+        "e22": 2.0,
+        "e23": 2.0,
+        "e30": 2.0,
+        "e31": 2.0,
+        "e32": 2.0,
+        "e33": 2.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SplitNode",
+    "m_ObjectId": "6081aee0d2f14f91bf48511833fa30b8",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Split",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 2109.0,
+            "y": -27.0,
+            "width": 120.0,
+            "height": 149.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c4c44afc5c464666a9d96dbcd2874f20"
+        },
+        {
+            "m_Id": "fca85b6690674f4082a1efa9c58022ca"
+        },
+        {
+            "m_Id": "38a7c5f8425f4e52a8575493503180e6"
+        },
+        {
+            "m_Id": "05d3ff076b8a4807b9a1beb8e4ceb6a2"
+        },
+        {
+            "m_Id": "63a6198632bd46fd89dd143344b69c46"
+        }
+    ],
+    "synonyms": [
+        "separate"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "61feaee7723e42c9b549c5dad06db48f",
     "m_Group": {
@@ -861,10 +1305,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1161.0,
-            "y": 76.0,
+            "x": 895.0,
+            "y": -118.0,
             "width": 132.0,
-            "height": 34.00000762939453
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -883,6 +1327,21 @@
     "m_Property": {
         "m_Id": "4398db32afbb40bdb60df5b3540ed641"
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "63a6198632bd46fd89dd143344b69c46",
+    "m_Id": 4,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 
 {
@@ -960,8 +1419,8 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1432.0,
-            "y": 589.0,
+            "x": 1485.0,
+            "y": 581.0,
             "width": 183.0,
             "height": 251.0
         }
@@ -1025,6 +1484,9 @@
         },
         {
             "m_Id": "5c44dbdca0bf43078b0dce680252e0d6"
+        },
+        {
+            "m_Id": "8c7bb07588494cca891b0ca45ba379fe"
         }
     ]
 }
@@ -1041,10 +1503,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1157.0,
-            "y": 393.0000305175781,
-            "width": 118.0,
-            "height": 33.999969482421878
+            "x": 1215.0,
+            "y": 131.0,
+            "width": 131.0,
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1305,8 +1767,8 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1433.0,
-            "y": 35.999996185302737,
+            "x": 1167.0,
+            "y": -158.0,
             "width": 183.0,
             "height": 251.0
         }
@@ -1366,6 +1828,34 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "8c7bb07588494cca891b0ca45ba379fe",
+    "m_Guid": {
+        "m_GuidSerialized": "dc04caeb-8b3d-4e08-95f0-1791e3772178"
+    },
+    "m_Name": "AlphaClipThreshold",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "AlphaClipThreshold",
+    "m_DefaultReferenceName": "_AlphaClipThreshold",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.5,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
 }
 
 {
@@ -1453,8 +1943,8 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1728.0001220703125,
-            "y": 616.0000610351563,
+            "x": 1757.0,
+            "y": 583.0,
             "width": 208.0,
             "height": 302.0
         }
@@ -1482,6 +1972,40 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "b112733f332547ae9697de5d87832a8a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Alpha",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d338ae5fbe234374afdfecf0f2893f9d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Alpha"
 }
 
 {
@@ -1583,6 +2107,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "c4c44afc5c464666a9d96dbcd2874f20",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
     "m_ObjectId": "c5bc9f7ebc804979a82f5d3213bbf44b",
     "m_Group": {
@@ -1593,10 +2141,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1462.0001220703125,
-            "y": 884.0,
+            "x": 1516.0,
+            "y": 851.0,
             "width": 151.0,
-            "height": 34.00006103515625
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1653,10 +2201,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1149.0,
-            "y": 627.9999389648438,
+            "x": 1195.0,
+            "y": 620.0,
             "width": 153.0,
-            "height": 34.00006103515625
+            "height": 34.0
         }
     },
     "m_Slots": [
@@ -1689,10 +2237,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1729.0,
-            "y": 167.00001525878907,
+            "x": 1463.0,
+            "y": -27.0,
             "width": 208.0,
-            "height": 301.99993896484377
+            "height": 302.0
         }
     },
     "m_Slots": [
@@ -1761,6 +2309,21 @@
     },
     "isMainColor": false,
     "m_ColorMode": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d338ae5fbe234374afdfecf0f2893f9d",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Alpha",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
 }
 
 {
@@ -1993,5 +2556,20 @@
     },
     "m_Labels": [],
     "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "fca85b6690674f4082a1efa9c58022ca",
+    "m_Id": 1,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Tests/Runtime/EnvironmentDiffuseMaterialDescriptorGeneratorTest.cs
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Tests/Runtime/EnvironmentDiffuseMaterialDescriptorGeneratorTest.cs
@@ -30,7 +30,11 @@ namespace Segur.PolySpatialEnvironmentDiffuseShader.Tests.Runtime
             Assert.That(materialDescriptor.TextureSlots.ContainsKey("_BaseMap"), Is.True);
             Assert.That(materialDescriptor.TextureSlots.ContainsKey("_EmissionMap"), Is.True);
 
-            Assert.That(materialDescriptor.FloatValues.Count, Is.EqualTo(0));
+            Assert.That(materialDescriptor.FloatValues.Count, Is.GreaterThan(4));
+            Assert.That(materialDescriptor.FloatValues["_AlphaMode"], Is.EqualTo(0));
+            Assert.That(materialDescriptor.FloatValues["_TransparentWithZWrite"], Is.EqualTo(0));
+            Assert.That(materialDescriptor.FloatValues["_Cutoff"], Is.EqualTo(0.5f));
+            Assert.That(materialDescriptor.FloatValues["_DoubleSided"], Is.EqualTo(0));
 
             Assert.That(materialDescriptor.Colors.Count, Is.EqualTo(2));
             Assert.That(materialDescriptor.Colors.ContainsKey("_Color"), Is.False);


### PR DESCRIPTION
Close #1 

I fixed issues related to transparency and culling.

Specifically, I adjusted the MToon10's `AlphaMode` and `DoubleSided` etc. to be converted to the appropriate parameters of the shader.