### PR TITLE
Fix shader graph for visionOS Simulator

### DIFF
--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Shaders/EnvironmentDiffuse.shadergraph
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Shaders/EnvironmentDiffuse.shadergraph
@@ -870,7 +870,7 @@
     "m_ZWriteControl": 0,
     "m_AlphaMode": 0,
     "m_RenderFace": 2,
-    "m_AlphaClip": false,
+    "m_AlphaClip": true,
     "m_CastShadows": true,
     "m_ReceiveShadows": true,
     "m_SupportsLODCrossFade": false,

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Shaders/EnvironmentDiffuse.shadergraph
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Shaders/EnvironmentDiffuse.shadergraph
@@ -865,7 +865,7 @@
         "m_Id": "4428c42bab964935b9bcffad53788d3d"
     },
     "m_AllowMaterialOverride": true,
-    "m_SurfaceType": 0,
+    "m_SurfaceType": 1,
     "m_ZTestMode": 4,
     "m_ZWriteControl": 0,
     "m_AlphaMode": 0,


### PR DESCRIPTION
## Description
I have fixed a bug that the transparency process was not working correctly when viewed in the visionOS simulator. Specifically, I changed the default values of the Shader Graph as follows:
- `Surface Type` : `Transparent`
- `Alpha Clipping` : true


## Related Issues
Fix #1 


## Testing
I checked in the following environments:
- Scene View of Unity Editor
- Game View of Unity Editor
- visionOS Simulator
- Apple Vision Pro


## Notes
Shader Graph's `Allow Material Override` doesn't seem to be working with visionOS.
I will continue to investigate and if I find that visionOS does not support `Allow Material Override`, I will make significant changes to the shader implementation.