### PR TITLE
Add Version Define for VRM v0.125.0+ compatibility in asmdef

### DIFF
--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/Unity.PolySpatialEnvironmentDiffuseShader.asmdef
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Runtime/Unity.PolySpatialEnvironmentDiffuseShader.asmdef
@@ -16,17 +16,17 @@
     "versionDefines": [
         {
             "name": "com.vrmc.gltf",
-            "expression": "",
+            "expression": "0.125.0",
             "define": "COM_VRMC_GLTF"
         },
         {
             "name": "com.vrmc.vrm",
-            "expression": "",
+            "expression": "0.125.0",
             "define": "COM_VRMC_VRM"
         },
         {
             "name": "com.unity.polyspatial",
-            "expression": "",
+            "expression": "0.125.0",
             "define": "USE_POLYSPATIAL"
         }
     ],

--- a/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Tests/Runtime/Unity.PolySpatialEnvironmentDiffuseShader.Tests.asmdef
+++ b/PolySpatialEnvironmentDiffuseShader/Packages/com.segur.poly-spatial-environment-diffuse-shader/Tests/Runtime/Unity.PolySpatialEnvironmentDiffuseShader.Tests.asmdef
@@ -23,7 +23,7 @@
     "versionDefines": [
         {
             "name": "com.vrmc.gltf",
-            "expression": "",
+            "expression": "0.125.0",
             "define": "COM_VRMC_GLTF"
         }
     ],


### PR DESCRIPTION
## Description
Added a Version Define to the .asmdef file to ensure compatibility only with VRM v0.125.0 or later.
This prevents the package from being compiled when older VRM versions (e.g., ≤ v0.124.x) are used.

## Related Issues
#14

## Testing

I checked in the following environments:

- [x] Scene View of Unity Editor
- [x] Game View of Unity Editor
- [ ] visionOS Simulator
- [ ] Apple Vision Pro


## Notes
Added a Version Define to the .asmdef file to ensure compatibility only with VRM v0.125.0 or later.
This prevents the package from being compiled when older VRM versions (e.g., ≤ v0.124.x) are used.
